### PR TITLE
Add Drip Analytics

### DIFF
--- a/_includes/analytics.html
+++ b/_includes/analytics.html
@@ -1,0 +1,27 @@
+{% if site.analytics.provider and page.analytics != false %}
+
+{% case site.analytics.provider %}
+{% when "google" %}
+  {% include /analytics-providers/google.html %}
+{% when "google-universal" %}
+  {% include /analytics-providers/google-universal.html %}
+{% when "custom" %}
+  {% include /analytics-providers/custom.html %}
+{% endcase %}
+
+<!-- Drip -->
+<script type="text/javascript">
+  var _dcq = _dcq || [];
+  var _dcs = _dcs || {};
+  _dcs.account = '3271024';
+
+  (function() {
+    var dc = document.createElement('script');
+    dc.type = 'text/javascript'; dc.async = true;
+    dc.src = '//tag.getdrip.com/3271024.js';
+    var s = document.getElementsByTagName('script')[0];
+    s.parentNode.insertBefore(dc, s);
+  })();
+</script>
+
+{% endif %}


### PR DESCRIPTION
Add Drip Analytics to the analytics.html include. I'll add a way to do this better in the future, possibly even submit a PR to the theme in case anyone else wants Drip integrations.